### PR TITLE
Operon's External Cross References Fix

### DIFF
--- a/ecocyc_extractor/ecocyc/domain/operon.py
+++ b/ecocyc_extractor/ecocyc/domain/operon.py
@@ -32,14 +32,13 @@ class Operon(object):
             self._db_links.extend(utils.get_external_cross_references(external_cross_references))
         except TypeError:
             pass
-            
-        ecocyc_reference = {
-            "externalCrossReferences_id": "|ECOCYC|",
-            "objectId": self.id.replace("|", ""),
-        }
-        
-        if ecocyc_reference not in self._db_links:
-            self._db_links.append(ecocyc_reference.copy())
+        for tu_id in self.transcription_unit_ids:
+            ecocyc_reference = {
+                "externalCrossReferences_id": "|ECOCYC|",
+                "objectId": tu_id.replace("|", ""),
+            }
+            if ecocyc_reference not in self._db_links:
+                self._db_links.append(ecocyc_reference.copy())
     
     @property
     def id(self):


### PR DESCRIPTION
# Operon's External Cross References Fix

## Description

There were some problems in the externalCrossReferences of the Operons. It was decided to leave the IDs that make up the Operon for each reference to Ecocyc


## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] The corresponding tests were carried out for the extraction of each of the classes. The resulting jsons were verified with the corresponding schemas. All the data that were giving problems during the extraction were taken care of and were solved.

**Test Configuration**:

- Python[3.9]
- Pathway Tools [24.5/25.0]
- Ecocyc Release [24.5/25.0]
- RegulonDB Release [1.0]

<!--Add images or diagrams if needed -->

## Checklist:

<!--Please delete options that are not relevant.-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings