### PR TITLE
Ecocyc Extractor 2.0.5 Ecocyc 27.5 RegulonDB 12.5

### DIFF
--- a/.run/Extract  Products.run.xml
+++ b/.run/Extract  Products.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract  Products" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-pd -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract All Publications.run.xml
+++ b/.run/Extract All Publications.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract All Publications" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-allpb -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract All.run.xml
+++ b/.run/Extract All.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract All" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-a -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Evidences.run.xml
+++ b/.run/Extract Evidences.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Evidences" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-ev -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract External DBs.run.xml
+++ b/.run/Extract External DBs.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract External DBs" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-extdb -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract GO Terms.run.xml
+++ b/.run/Extract GO Terms.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract GO Terms" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-gotm -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Genes.run.xml
+++ b/.run/Extract Genes.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Genes" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-gn -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Mfun Ontologies.run.xml
+++ b/.run/Extract Mfun Ontologies.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Mfun Ontologies" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-mot -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Mfun Terms.run.xml
+++ b/.run/Extract Mfun Terms.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Mfun Terms" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-mft -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Motifs.run.xml
+++ b/.run/Extract Motifs.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Motifs" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-mt -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Ontologies.run.xml
+++ b/.run/Extract Ontologies.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Ontologies" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-got -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Operons.run.xml
+++ b/.run/Extract Operons.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Operons" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-op -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Promoters.run.xml
+++ b/.run/Extract Promoters.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Promoters" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-pm -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Regulatory Comlpexes.run.xml
+++ b/.run/Extract Regulatory Comlpexes.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Regulatory Comlpexes" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-rcplx -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Regulatory Continuants.run.xml
+++ b/.run/Extract Regulatory Continuants.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Regulatory Continuants" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-rc -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Regulatory Intercations.run.xml
+++ b/.run/Extract Regulatory Intercations.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Regulatory Intercations" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-ri -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Regulatory Sites.run.xml
+++ b/.run/Extract Regulatory Sites.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Regulatory Sites" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-st -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Segments.run.xml
+++ b/.run/Extract Segments.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Segments" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-sg -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Sigma Factors.run.xml
+++ b/.run/Extract Sigma Factors.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Sigma Factors" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-sf -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract TFs.run.xml
+++ b/.run/Extract TFs.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract TFs" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-tf -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract TUs.run.xml
+++ b/.run/Extract TUs.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract TUs" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-tu -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Extract Terminators.run.xml
+++ b/.run/Extract Terminators.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Extract Terminators" type="PythonConfigurationType" factoryName="Python">
+    <module name="ecocyc-extractor" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="ecocyc_extractor/__main__.py" />
+    <option name="PARAMETERS" value="-tm -out ../RawData/ -l logs/ecocyc_extractor_log/" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This version is for extraction process with new Ecocyc release 27.5 for the RegulonDB 12.5 release.
 
-## [2.0.5](https://github.com/regulondbunam/ecocyc-extractor/releases/tag/2.0.5) - 2024-01-23
+## [2.0.5](https://github.com/regulondbunam/ecocyc-extractor/releases/tag/2.0.5) - 2024-01-24
 
 ### Added
 
@@ -16,6 +16,7 @@ This version is for extraction process with new Ecocyc release 27.5 for the Regu
 ### Deprecated
 
 - Removed some debug outputs.
+- Snakemake env that sets python 2.7 now its python 3.10
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Ecocyc Extractor Changelog
 
-This version is for extraction process with new Ecocyc release 27.0 for the RegulonDB 12.0 release.
+This version is for extraction process with new Ecocyc release 27.5 for the RegulonDB 12.5 release.
 
-## [2.0.4](https://github.com/regulondbunam/ecocyc-extractor/releases/tag/2.0.4) - 2023-09-14
+## [2.0.5](https://github.com/regulondbunam/ecocyc-extractor/releases/tag/2.0.5) - 2024-01-23
 
 ### Added
 
@@ -10,14 +10,12 @@ This version is for extraction process with new Ecocyc release 27.0 for the Regu
 
 ### Changed
 
-- TF Conformations are only registered if not are in TF IDs list.
-- Products abbv_name and name extracted as expected.
-- SigmaFactors abbv_name and name extracted as expected.
-- TF abbv_name and name extracted as expected.
+- Banners versions in Readme updated.
+- Config file versions update.
 
 ### Deprecated
 
-- Without changes.
+- Removed some debug outputs.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
   <img alt="RegulonDB Logo" style="width:50%;height:25%;" src="https://drive.google.com/uc?export=view&id=1BtKqNvtchMidDMUSyeJZPCnfMb-saaYm"></img>
 </p>
 
-[![License](https://img.shields.io/badge/license-MIT-brightgreen?style=plastic)](LICENSE)
-[![RegulonDBVersion](https://img.shields.io/badge/RegulonDB_version-12.0-blue?style=plastic)](https://regulondb.ccg.unam.mx/)
-[![EcocycVersion](https://img.shields.io/badge/last_Ecocyc_version_tested-27.0-red?style=plastic)](https://ecocyc.org/)
-[![Status](https://img.shields.io/badge/status-release_candidate-yellowgreen?style=plastic)](CHANGELOG.md)
+[![License](https://img.shields.io/badge/license-APACHE-brightgreen?style=plastic)](LICENSE)
+[![RegulonDBVersion](https://img.shields.io/badge/RegulonDB_version-12.5-blue?style=plastic)](https://regulondb.ccg.unam.mx/)
+[![EcocycVersion](https://img.shields.io/badge/last_Ecocyc_version_tested-27.5-red?style=plastic)](https://ecocyc.org/)
+[![Status](https://img.shields.io/badge/status-release_2.0.5-yellowgreen?style=plastic)](CHANGELOG.md)
 
 This [software](https://lucid.app/folder/invitations/accept/813e6281-f3fb-4a08-967a-251e1e5af6b7) has the function of extracting the information from the Ecocyc database and transforming it for use in RegulonDB with respect to the [Multigenomic Model](https://app.lucidchart.com/lucidchart/invitations/accept/0056e953-5ccb-439d-9411-afcb9c875953)
 
@@ -23,7 +23,7 @@ This software was made to extract all the necessary data from Ecocyc.
   - [Python 3.10](https://www.python.org/) or above
   - [RegulonDB PythonCyc Fork](https://github.com/regulondbunam/PythonCyc)
   - [PathwayTools Docker](https://github.com/pablo-epl/pathway-tools-docker)
-  - [PathwayTools 27.0](http://bioinformatics.ai.sri.com/ptools/)
+  - [PathwayTools 27.5](http://bioinformatics.ai.sri.com/ptools/)
 - Hardware:
   - RAM: 8 GB (recommended)
   

--- a/Snakefile
+++ b/Snakefile
@@ -15,8 +15,8 @@ rule ecocyc_extractor_workflow:
         compose_file = {ptools_config["compose_file"]}, # -f
         dotenv_file = {ptools_config["dotenv_file"]}, # --env-file
     input:
-        #"logs/ptools_docker_log/ptools_docker_log.log",
-        #"logs/ecocyc_extractor_log/ecocyc_extractor_log.log",
+        "logs/ptools_docker_log/ptools_docker_log.log",
+        "logs/ecocyc_extractor_log/ecocyc_extractor_log.log",
         "logs/schema_loader_log/schema_loader_log.log",
         "logs/validation_log/validation_log.log",
         "logs/create_identifiers_log/create_identifiers_log.log",
@@ -27,7 +27,7 @@ rule ecocyc_extractor_workflow:
         "logs/ecocyc_extractor_log.log"
     run:
         shell('python ../log_cleaner/log_cleaner.py'),
-        #shell("docker-compose -f {params.compose_file} --env-file {params.dotenv_file} stop")
+        shell("docker-compose -f {params.compose_file} --env-file {params.dotenv_file} stop")
 
 rule ptools_docker:
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -29,7 +29,7 @@ rule ecocyc_extractor_workflow:
         shell('python ../log_cleaner/log_cleaner.py'),
         #shell("docker-compose -f {params.compose_file} --env-file {params.dotenv_file} stop")
 
-'''rule ptools_docker:
+rule ptools_docker:
     params:
         compose_file = {ptools_config["compose_file"]}, # -f
         dotenv_file = {ptools_config["dotenv_file"]} # --env-file
@@ -41,8 +41,8 @@ rule ecocyc_extractor_workflow:
         shell("docker-compose -f {params.compose_file} --env-file {params.dotenv_file} up -d")
         shell('echo "Please Wait for PTools Startup"')
         shell("sleep 10s")
-'''        
-'''rule ecocyc_extractor:
+        
+rule ecocyc_extractor:
     params:
         main_path = ecocyc_extractor_config["main_path"],
         output_dir = ecocyc_extractor_config["raw_data"],
@@ -56,7 +56,7 @@ rule ecocyc_extractor_workflow:
     priority: 10
     shell:
         "python {params.main_path} -a -out {params.output_dir} -l {params.log_dir}"
-'''
+
 
 rule schema_loader:
     params:
@@ -72,7 +72,7 @@ rule schema_loader:
     priority: 9
     shell:
         "python {params.main_path} -db {params.db} -u {params.url} -s {params.schemas} -l {params.log} -d"
-        
+     
 
 rule data_validator:
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -72,7 +72,7 @@ rule schema_loader:
     priority: 9
     shell:
         "python {params.main_path} -db {params.db} -u {params.url} -s {params.schemas} -l {params.log} -d"
-     
+
 
 rule data_validator:
     params:

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
   "url": "mongodb://127.0.0.1:27017",
   "db": "regulondbmultigenomic",
   "organism": "ECOLI",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "source": "EcoCyc",
   "source_version": 27.0,
   "ptools_config": {

--- a/config/config.json
+++ b/config/config.json
@@ -2,9 +2,10 @@
   "url": "mongodb://127.0.0.1:27017",
   "db": "regulondbmultigenomic",
   "organism": "ECOLI",
-  "version": "12.0.2",
+  "version": "12.5.0",
   "source": "EcoCyc",
-  "source_version": 27.0,
+  "source_version": 27.5,
+  "extractor_version": "2.0.5",
   "ptools_config": {
     "compose_file": "../pathway_tools_docker/docker-compose.yml",
     "dotenv_file": "../pathway_tools_docker/.env"

--- a/config/config.json
+++ b/config/config.json
@@ -7,8 +7,8 @@
   "source_version": 27.5,
   "extractor_version": "2.0.5",
   "ptools_config": {
-    "compose_file": "../pathway_tools_docker/docker-compose.yml",
-    "dotenv_file": "../pathway_tools_docker/.env"
+    "compose_file": "../pathway_tools_docker/pathway-tools-docker/docker-compose.yml",
+    "dotenv_file": "../pathway_tools_docker/pathway-toolsdocker/.env"
   },
   "ecocyc_extractor_config": {
     "main_path": "ecocyc_extractor",
@@ -16,39 +16,39 @@
     "log_dir": "logs/ecocyc_extractor_log/"
   },
   "schema_loader_config": {
-    "main_path": "../data-release-tools/src/schema_loader/",
-    "schemas": "../MultigenomicModel/schemas/json_schema_validation",
+    "main_path": "../../data-release-tools/src/schema_loader/",
+    "schemas": "../../MultigenomicModel/schemas/json_schema_validation",
     "log_dir": "logs/schema_loader_log/"
   },
   "validation_config": {
-    "main_path": "../data-release-tools/src/data_validator/",
+    "main_path": "../../data-release-tools/src/data_validator/",
     "raw_data": "../RawData/",
-    "schemas": "../MultigenomicModel/schemas/json_schema_validation",
+    "schemas": "../../MultigenomicModel/schemas/json_schema_validation",
     "verified_data": "../VerifiedData",
     "invalid_data": "../InvalidData",
     "log_dir": "logs/validation_log/"
   },
   "create_identifiers_config": {
-    "main_path": "../data-release-tools/src/create_identifiers/",
+    "main_path": "../../data-release-tools/src/create_identifiers/",
     "verified_data": "../VerifiedData",
     "log_dir": "../logs/create_identifiers_log/"
   },
   "replace_identifiers_config": {
-    "main_path": "../data-release-tools/src/replace_identifiers/",
+    "main_path": "../../data-release-tools/src/replace_identifiers/",
     "verified_data": "../VerifiedData",
     "persistent_ids": "../PersistentIdentifiers",
     "log_dir": "../logs/replace_identifiers_log/"
   },
   "revalidation_config": {
-    "main_path": "../data-release-tools/src/data_validator/",
+    "main_path": "../../data-release-tools/src/data_validator/",
     "persistent_ids": "../PersistentIdentifiers",
-    "schemas": "../MultigenomicModel/schemas/json_schema_validation",
+    "schemas": "../../MultigenomicModel/schemas/json_schema_validation",
     "verified_persistent_ids": "../VerifiedPersistentIdentifiers",
     "invalid_data": "../InvalidData",
     "log_dir": "../logs/re_validation_log/"
   },
   "data_upload_config": {
-    "main_path": "../data-release-tools/src/data_uploader/",
+    "main_path": "../../data-release-tools/src/data_uploader/",
     "verified_persistent_ids": "../VerifiedPersistentIdentifiers",
     "log_dir": "../logs/data_uploader_log/"
   }

--- a/ecocyc_extractor/__main__.py
+++ b/ecocyc_extractor/__main__.py
@@ -28,6 +28,7 @@ from regulondb import growth_condition_phrase_catalogs
 
 from libs import arguments
 from libs import utils
+from libs import banner
 
 
 def set_json_object(filename, objects_to_json, organism, class_acronym, subclass_acronym):
@@ -62,6 +63,7 @@ def set_json_object(filename, objects_to_json, organism, class_acronym, subclass
 
 
 if __name__ == '__main__':
+    banner.show_banner()
     arguments = arguments.load_arguments()
 
     # organism usage can be seen in the utils.constants module and on the

--- a/ecocyc_extractor/ecocyc/collections/transcription_factors.py
+++ b/ecocyc_extractor/ecocyc/collections/transcription_factors.py
@@ -66,12 +66,15 @@ class TranscriptionFactors(object):
 
             regulator_classes = TranscriptionFactor.pt_connection.get_frame_all_parents(
                 regulator_id)
-
+            # print(regulator_id)
             if not monomer_ids and EC.COMPOUNDS_CLASS not in regulator_classes:
+                # print('\t No monomers and regulator not in compound_class')
                 transcription_factor_ids.append(regulator_id)
             if len(monomer_ids) == 1:
+                # print('\t Only one monomer')
                 transcription_factor_ids.append(monomer_ids[0])
             elif len(monomer_ids) > 1:
+                # print('\t More than one monomers')
                 # For those TFs that are protein dimers, that is to say, that is formed through two different
                 # polypeptides we save the protein complex(dimer) and store it as a TF, they will be seen in the
                 # regulatory complexes collection in the property isTranscriptionFactor = True

--- a/ecocyc_extractor/ecocyc/domain/evidence.py
+++ b/ecocyc_extractor/ecocyc/domain/evidence.py
@@ -26,6 +26,7 @@ class Evidence(Base):
     def code(self, name=None):
         if name is not None:
             self._code = (self.id).replace("EV-", "")
+            self._code = (self.id).replace("|", "")
         else:
             self._code = None
 

--- a/ecocyc_extractor/ecocyc/domain/publication.py
+++ b/ecocyc_extractor/ecocyc/domain/publication.py
@@ -25,10 +25,11 @@ class Publication(Base):
     def authors(self, authors=None):
         if authors:
             authors = authors
+            ''' For testing when authors names are disordered and/or repeated
             if len(authors) != len(list(set(authors))):
                 print(self.pmid)
                 print(authors)
-                print(list(set(authors)))
+                print(list(set(authors)))'''
         self._authors = authors
 
     @property

--- a/ecocyc_extractor/libs/banner.py
+++ b/ecocyc_extractor/libs/banner.py
@@ -1,0 +1,27 @@
+import json
+
+with open('config/config.json') as json_file:
+    data = json.load(json_file)
+
+print()
+
+regulondb_version = data.get('version')
+ecocyc_version = data.get('source_version')
+extractor_version = data.get('extractor_version')
+
+banner = f"""
+REGULONDB's
+███████╗ ██████╗ ██████╗  ██████╗██╗   ██╗ ██████╗    ███████╗██╗  ██╗████████╗██████╗  █████╗  ██████╗████████╗ ██████╗ ██████╗ 
+██╔════╝██╔════╝██╔═══██╗██╔════╝╚██╗ ██╔╝██╔════╝    ██╔════╝╚██╗██╔╝╚══██╔══╝██╔══██╗██╔══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗
+█████╗  ██║     ██║   ██║██║      ╚████╔╝ ██║         █████╗   ╚███╔╝    ██║   ██████╔╝███████║██║        ██║   ██║   ██║██████╔╝
+██╔══╝  ██║     ██║   ██║██║       ╚██╔╝  ██║         ██╔══╝   ██╔██╗    ██║   ██╔══██╗██╔══██║██║        ██║   ██║   ██║██╔══██╗
+███████╗╚██████╗╚██████╔╝╚██████╗   ██║   ╚██████╗    ███████╗██╔╝ ██╗   ██║   ██║  ██║██║  ██║╚██████╗   ██║   ╚██████╔╝██║  ██║
+╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝    ╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+Version: {regulondb_version}
+RegulonDB Version: {regulondb_version}
+Ecocyc Version: {ecocyc_version}
+GitHub: https://github.com/regulondbunam/ecocyc-extractor
+"""
+def show_banner():
+    print(banner)

--- a/envs/db_dependencies.yaml
+++ b/envs/db_dependencies.yaml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - local
 dependencies:
-  - python = 3.9
   - mongoengine
   - pymongo = 3.12.1
   - dnspython

--- a/envs/ecocyc_dependencies.yaml
+++ b/envs/ecocyc_dependencies.yaml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - local
 dependencies:
-  - python = 3.10
   - pip
   - pip:
       - ../../../libs/PythonCyc-master/

--- a/envs/py_down_grade.yaml
+++ b/envs/py_down_grade.yaml
@@ -2,5 +2,4 @@ channels:
  - bioconda
  - conda-forge
 dependencies:
- - python = 2.7
- - jsonschema
+ - jsonschema 

--- a/test/pub_med_authors.py
+++ b/test/pub_med_authors.py
@@ -31,11 +31,13 @@ def get_pubmed_data(pmid, email='reguadm@ccg.unam.mx'):
     publication = {}
     record = Medline.read(handle)
     pubmed_authors = record.get('AU')
-    print(record)
+    # print(record)
     if isinstance(pubmed_authors, str):
         pubmed_authors = pubmed_authors.split(',')
     publication.setdefault('authors', pubmed_authors)
-    publication.setdefault('abstract', record.get('AB'))
+    publication.setdefault('internalComents', record.get('IC'))
+    publication.setdefault('source', record.get('SO'))
+    # publication.setdefault('abstract', record.get('AB'))
     publication.setdefault('date', record.get('DP'))
     publication.setdefault('pmcid', record.get('PMC'))
     publication.setdefault('pmid', int(record.get('PMID')))
@@ -50,6 +52,15 @@ def get_pubmed_data(pmid, email='reguadm@ccg.unam.mx'):
     return publications
 
 
-pmid = 12558182
-pubmed_publication = get_pubmed_data(pmid=pmid)
-print(pubmed_publication)
+pmid = 34824476
+pmids = [
+    34824476,
+    29394395,
+    26843427,
+    34791440,
+    33172971,
+    34196371
+]
+for pmid in pmids:
+    pubmed_publication = get_pubmed_data(pmid=pmid)
+    print(pubmed_publication, '\n\n\n')


### PR DESCRIPTION
# Ecocyc Extractor 2.0.5

## Description

This version if for the extraction process for the new Ecocyc release 27.5 for the RegulonDB 12.5 release. 


## Type of change

- [x] Versionament Update
- [x] This change requires a documentation update
### Added

- Banner displayed on program run.

### Changed

- Pipe, "|", removed from Evidence Code.
- Updated banners versions in README file.
- Config file versions update.
- Snakemake env file update.

### Deprecated

- Removed some debug outputs.

### Fixed

- Without changes.

### To Fix

- Without changes.


**Test Configuration**:

- Python 3.11
- Pathway Tools 27.5
- Ecocyc Release 27.5
- RegulonDB Release 12.5


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

